### PR TITLE
[FEAT] CAP 커맨드 구현 추가

### DIFF
--- a/src/commands/Cap.cpp
+++ b/src/commands/Cap.cpp
@@ -6,19 +6,29 @@
 /*   By: yechakim <yechakim@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/17 07:27:35 by yechakim          #+#    #+#             */
-/*   Updated: 2025/02/17 11:54:44 by yechakim         ###   ########.fr       */
+/*   Updated: 2025/02/18 12:12:05 by yechakim         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "IRCCommand.hpp"
 #include <iostream>
-
-namespace IRCCommand{
+/**
+ * CAP Comamand
+ * 
+ * 아래와 같은 요청이 왔을때 요청을 처리합니다.
+ * - CAP LS
+ * - CAP LS 302
+ */
+namespace IRCCommand {
   void cap(fd clientSocket, void* message){
-    (void)message;
+    Message *msg = (Message*)message;
+    std::vector<std::string> params = msg->getParams();
     IRCServer &ircServer = IRCServer::getInstance();
     UserRepository &users = UserRepository::getInstance();
-    users.getUser(clientSocket)->send("CAP * LS:");
-    ircServer.enableWriteEvent(clientSocket);
+    User *user = users.getUser(clientSocket);
+    if (params.size() > 2 && params[1] == "LS"){
+      user->send("CAP * LS :");
+      ircServer.enableWriteEvent(clientSocket);
+    }
   }
 }


### PR DESCRIPTION
# 작업사항

- `CAP LS`에 대한 응답을 추가합니다. 
- 현재 저희 프로젝트에서는 추가적인 기능들을 지원하지 않으므로 
- 응답은 항상 `CAP * LS`입니다.