### PR TITLE
[FIX] 채널레포지토리의 getChannel의 리턴타입변경

### DIFF
--- a/src/server/ChannelRepository.cpp
+++ b/src/server/ChannelRepository.cpp
@@ -21,7 +21,7 @@ void ChannelRepository::destroy()
   }
 }
 
-void ChannelRepository::addChannel(Channel & channel)
+void ChannelRepository::addChannel(Channel channel)
 {
   if (hasChannel(channel.getName())) {
       throw std::invalid_argument("Channel already exists");
@@ -42,15 +42,15 @@ ChannelRepository::~ChannelRepository()
   
 }
 
-Channel & ChannelRepository::getChannel(channelName name)
+Channel *ChannelRepository::getChannel(std::string const &name)
 {
   if(!hasChannel(name)) {
-    throw std::invalid_argument("Channel does not exist");
+    return NULL;
   }
-  return channels[name];
+  return &channels[name];
 }
 
-bool ChannelRepository::hasChannel(channelName name)
+bool ChannelRepository::hasChannel(std::string const &name)
 {
   if(channels.find(name) != channels.end()) {
     return true;

--- a/src/server/ChannelRepository.hpp
+++ b/src/server/ChannelRepository.hpp
@@ -12,10 +12,10 @@ class ChannelRepository {
       static ChannelRepository &getInstance();
       static void destroy();
 
-      void addChannel(Channel & channel);
+      void addChannel(Channel channel);
       void removeChannel(Channel & channel);
-      Channel &getChannel(std::string name);
-      bool hasChannel(std::string name);
+      Channel *getChannel(std::string const &name);
+      bool hasChannel(std::string const &name);
     private:
       static ChannelRepository *instance;
       std::map<std::string, Channel> channels;


### PR DESCRIPTION
# 작업사항

- ChannelRepository::getChannel() 메소드의 리턴타입을 포인터로 변경합니다.

