### PR TITLE
[FEAT] implement INVITE command

### DIFF
--- a/src/commands/IRCCommand.hpp
+++ b/src/commands/IRCCommand.hpp
@@ -55,7 +55,7 @@ namespace IRCCommand{
 
   // // for chop
   void kick(int clientSocket, void* message);
-  // void invite(int clientSocket, void* message);
+  void invite(int clientSocket, void* message);
   // void topic(int clientSocket, void* message);
   // void mode(int clientSocket, void* message);
   

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -154,6 +154,10 @@ bool Channel::isLimit()
   return mode & MODE_LIMIT;
 }
 
+bool Channel::isInvited(User & user){
+  return invitedUsers.find(&user) != invitedUsers.end();
+}
+
 bool Channel::authenticate(std::string key)
 {
   return key == this->key;
@@ -165,4 +169,6 @@ void Channel::setMode(std::string mode, std::vector<std::string> keys)
   (void)keys;
 }
 
-
+void Channel::invite(User & user) {
+  invitedUsers.insert(&user);
+}

--- a/src/server/Channel.hpp
+++ b/src/server/Channel.hpp
@@ -30,6 +30,8 @@ class Channel {
     size_t capacity;
     std::string topic;
     char mode;
+    std::set<User *> invitedUsers;
+
 
 
   public:
@@ -55,10 +57,12 @@ class Channel {
     bool isKeyProtected();
     bool isOperator(User &user);
     bool isLimit();
+    bool isInvited(User &user);
+
     bool authenticate(std::string key);
     void setMode(std::string mode, std::vector<std::string> keys);
-    
-    void sendBufferFlush();
+    void invite(User &user);
+
 };
 
 


### PR DESCRIPTION
# 작업사항

- INVITE 커맨드를 구현합니다. 
- INVITE에서 뱉어야하는 오류응답들이 많습니다. 다음과 같은 우선순위로 처리합니다. 
  1. 파라미터의 충분
  2. 초대되는 대상의 존재
  3. 채널의 존재
  4. 채널에 초대자의 존재  
  5. 채널의 모드가 초대전용모드일 때, 초대자가 오퍼레이터 권한
  6. 초대되는 채널에 초대받는 대상의 존재
 